### PR TITLE
Making hjson work with Lua 5.1

### DIFF
--- a/hjson/encoderH.lua
+++ b/hjson/encoderH.lua
@@ -9,7 +9,7 @@ local escape_char_map = {
     ["\t"] = "\\t"
 }
 
-local COMMONRANGE = "\x7f-\x9f" -- // TODO: add unicode escape sequences
+local COMMONRANGE = "\127-\159" -- // TODO: add unicode escape sequences
 
 local function containsSequences(s, sequences)
     for _, v in ipairs(sequences) do if s:find(v) then return true end end
@@ -17,20 +17,20 @@ local function containsSequences(s, sequences)
 end
 
 local function needsEscape(s)
-    return containsSequences(s, {'[\\"\x00-\x1f' .. COMMONRANGE .. "]"})
+    return containsSequences(s, {"%z", '[\\"\001-\031' .. COMMONRANGE .. "]"})
 end
 
 local function needsQuotes(s)
     local sequences = {
         "^%s", '^"', "^'", "^#", "^/%*", "^//", "^{", "^}", "^%[", "^%]", "^:",
-        "^,", "%s$", "[\x00-\x1f" .. COMMONRANGE .. "]"
+        "^,", "%s$", "%z", "[\001-\031" .. COMMONRANGE .. "]"
     }
     return containsSequences(s, sequences)
 end
 
 local function needsEscapeML(s)
     local sequences = {
-        "'''", "^[\\s]+$", "[\x00-\x08\x0b\x0c\x0e-\x1f" .. COMMONRANGE .. "]"
+        "'''", "^[\\s]+$", "%z", "[\01-\08\011\012\014-\031" .. COMMONRANGE .. "]"
     }
     return containsSequences(s, sequences)
 end


### PR DESCRIPTION
I am wanting to use hjson from within the Defold game engine, which embeds Lua 5.1. So I did what I needed to do to make it work under 5.1. Also verified that it works on 5.3 and 5.4. I have not touched the rockspec.

The hex escape codes in strings (like "\x7f") were added in Lua 5.2. But before this, decimal escape codes (like "\127") did exists. Replacing the hex escape codes with decimal ones makes hjson-lua work with Lua 5.1.

Worth noting that \00 does not work in patterns. So this change uses the %z character class to match character 0x00.